### PR TITLE
build static files and serve with nginx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM node:14
+FROM node:14 as build-stage
 WORKDIR /dspfront
 COPY package*.json ./
-RUN npm i @vue/cli-service
-RUN npm install --production
-COPY . .
+RUN npm install
+COPY ./ .
 RUN npm run build-prod
+
+FROM nginx:1.23.1 as production-stage
+RUN mkdir /dspfront
+COPY --from=build-stage /dspfront/dist /dspfront
+COPY nginx.conf /etc/nginx/nginx.conf
 EXPOSE 5001
-CMD ["npm", "run", "serve-prod", "--", "--port", "5001", "--host", "dspfront"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,30 @@
+user  nginx;
+worker_processes  1;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+events {
+  worker_connections  1024;
+}
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log  /var/log/nginx/access.log  main;
+  sendfile        on;
+  keepalive_timeout  65;
+  server {
+    listen       5001;
+    server_name  localhost;
+    location / {
+      root   /dspfront;
+      index  index.html;
+      try_files $uri $uri/ /index.html;
+    }
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+      root   /usr/share/nginx/html;
+    }
+  }
+}


### PR DESCRIPTION
These changes update the Dockerfile serving dspfront from vue-cli-service to nginx.  It is served to the same ports so no changes are necessary to deploy.

Deployed to alpha for testing. https://dsp-alpha.criticalzone.org/