### PR TITLE
Enable $data keyword in createAjv

### DIFF
--- a/src/components/new-submission/cz.new-submission.vue
+++ b/src/components/new-submission/cz.new-submission.vue
@@ -288,7 +288,7 @@ const renderers = [
   ...CzRenderers,
 ];
 const sprintf = require("sprintf-js").sprintf;
-const customAjv = createAjv({ allErrors: true });
+const customAjv = createAjv({ allErrors: true, $data: true });
 ajvErrors(customAjv);
 
 @Component({


### PR DESCRIPTION
Use $data keyword in `createAjv` options to enable use of schema validations such as `formatMinimum`.

![image](https://github.com/cznethub/dspfront/assets/2448568/c1410988-5af3-4aaa-bcff-4a6eb10d566a)
